### PR TITLE
add some aliases for ls, not having ll or l is just nerve wracking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN gem install puppet
 RUN gem install r10k
 RUN gem install puppet-lint
+ 
+COPY bashrc /root/.bashrc
 
 COPY gitconfig /root/.gitconfig
 

--- a/bashrc
+++ b/bashrc
@@ -1,0 +1,19 @@
+# ~/.bashrc: executed by bash(1) for non-login shells.
+
+# Note: PS1 and umask are already set in /etc/profile. You should not
+# need this unless you want different defaults for root.
+# PS1='${debian_chroot:+($debian_chroot)}\h:\w\$ '
+# umask 022
+
+# You may uncomment the following lines if you want `ls' to be colorized:
+export LS_OPTIONS='--color=auto'
+#eval "`dircolors`"
+alias ls='ls $LS_OPTIONS'
+alias ll='ls $LS_OPTIONS -l'
+alias l='ls $LS_OPTIONS -lA'
+
+# Some more alias to avoid making mistakes:
+# alias rm='rm -i'
+# alias cp='cp -i'
+# alias mv='mv -i'
+


### PR DESCRIPTION
After applying puppet you often want to check if something happened in directories or similar. Having `ll` or `l` enabled by default as on most other systems will be helpful with that.
