### PR TITLE
Add setup script to simplify container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN gem install puppet
 RUN gem install r10k
 RUN gem install puppet-lint
+ 
+COPY bashrc /root/.bashrc
 
 COPY gitconfig /root/.gitconfig
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN gem install puppet
 RUN gem install r10k
 RUN gem install puppet-lint
  
+COPY bin /root/bin
+
 COPY bashrc /root/.bashrc
 
 COPY gitconfig /root/.gitconfig

--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ root@07e854d09c79:~#
 As your puppet-dev directory is mounted to the container by passing  ```-v```, all changes
 done on your host are immediately available on the container (and vice versa).
 
+To keep the image size small all cached information from apt is removed when the
+Docker image is build. To regain this information and to not let your puppet scripts
+fail in case they install additional packages, run the following command:
+
+```
+root@07e854d09c79:~# setup.sh
+```
+
+This will refresh the cache for apt.
+
 ### Include access keys in container
 The first thing you'll probably do is to run 'r10k' which fetches required modules
 from source repositories. If keys are required to access source repositories, mount
@@ -72,7 +82,13 @@ your personal keys to the container as well
 host:~/puppet-dev/$ docker run -it --rm -v $(pwd):/root/src -v ~/.ssh:/root/.ssh mattriesterer/docker-puppet-debian
 ```
 
-Then make the ssh-agent available
+When you run `setup.sh` as described above and mount the .ssh folder to `/root/.ssh`
+as in the example above, the setup script will take care of the following steps. In
+case you want to run them manually or that your key file is not named as one of the
+defaults that `ssh-add` will load when no specific key file is specified run the
+following commands:
+
+Make the ssh-agent available
 
 ```
 docker:~/$ eval $(ssh-agent)

--- a/bashrc
+++ b/bashrc
@@ -1,0 +1,19 @@
+# ~/.bashrc: executed by bash(1) for non-login shells.
+
+# Note: PS1 and umask are already set in /etc/profile. You should not
+# need this unless you want different defaults for root.
+# PS1='${debian_chroot:+($debian_chroot)}\h:\w\$ '
+# umask 022
+
+# You may uncomment the following lines if you want `ls' to be colorized:
+export LS_OPTIONS='--color=auto'
+#eval "`dircolors`"
+alias ls='ls $LS_OPTIONS'
+alias ll='ls $LS_OPTIONS -l'
+alias l='ls $LS_OPTIONS -lA'
+
+# Some more alias to avoid making mistakes:
+# alias rm='rm -i'
+# alias cp='cp -i'
+# alias mv='mv -i'
+

--- a/bashrc
+++ b/bashrc
@@ -17,3 +17,6 @@ alias l='ls $LS_OPTIONS -lA'
 # alias cp='cp -i'
 # alias mv='mv -i'
 
+# ensure helper scripts can be accessed
+export PATH="$PATH:/root/bin"
+

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# ensure package info is current so that puppet can find
+# packages to be installed
+apt-get update
+
+# ensure SSH agent is running and keys are loaded when
+# .ssh folder is present
+if [ -d /root/.ssh ]; then
+    eval $(ssh-agent)
+    ssh-add
+fi
+


### PR DESCRIPTION
This PR adds a setup script to allow for a simpler container startup so that a user doesn't have to type all the commands again and again on each startup.

We should think of whether the script should be called automatically on login, as that would remove the requirement to run this script manually.
